### PR TITLE
update runtime to latest

### DIFF
--- a/com.mastermindzh.tidal-hifi.yml
+++ b/com.mastermindzh.tidal-hifi.yml
@@ -1,6 +1,6 @@
 app-id: com.mastermindzh.tidal-hifi
 runtime: org.freedesktop.Platform
-runtime-version: "21.08"
+runtime-version: "22.08"
 sdk: org.freedesktop.Sdk
 separate-locales: false
 command: com.mastermindzh.tidal-hifi


### PR DESCRIPTION
This will help reduce the installed size for many users, as the latest runtime version is the most likely to be installed.