### PR TITLE
Update Title, Summary, Categories and Wayland/X11 handling

### DIFF
--- a/com.mastermindzh.tidal-hifi.metainfo.xml
+++ b/com.mastermindzh.tidal-hifi.metainfo.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>com.mastermindzh.tidal-hifi</id>
-  <name>tidal-hifi</name>
-  <summary>The web version of listen.tidal.com with hifi support</summary>
+  <name>TIDAL Hi-Fi</name>
+  <summary>The web version of listen.tidal.com with Hi-Fi (High & Max) support</summary>
   <developer_name>Rick van Lieshout</developer_name>
   <url type="homepage">https://github.com/Mastermindzh/tidal-hifi</url>
   <url type="bugtracker">
@@ -12,6 +12,8 @@
   <categories>
     <category>AudioVideo</category>
     <category>Audio</category>
+    <category>Player</category>
+    <category>Music</category>
   </categories>
   <description>
     <p>

--- a/com.mastermindzh.tidal-hifi.metainfo.xml
+++ b/com.mastermindzh.tidal-hifi.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>com.mastermindzh.tidal-hifi</id>
   <name>TIDAL Hi-Fi</name>
-  <summary>The web version of listen.tidal.com with Hi-Fi (High & Max) support</summary>
+  <summary>The web version of listen.tidal.com with Hi-Fi (High and Max) support</summary>
   <developer_name>Rick van Lieshout</developer_name>
   <url type="homepage">https://github.com/Mastermindzh/tidal-hifi</url>
   <url type="bugtracker">

--- a/com.mastermindzh.tidal-hifi.yml
+++ b/com.mastermindzh.tidal-hifi.yml
@@ -7,7 +7,7 @@ command: com.mastermindzh.tidal-hifi
 rename-desktop-file: tidal-hifi.desktop
 finish-args:
   - "--share=ipc"
-  - "--socket=x11"
+  - "--socket=fallback-x11"
   - "--socket=wayland"
   - "--socket=pulseaudio"
   - "--share=network"


### PR DESCRIPTION
This make sure to match the Summary and title up to the current standard in the repo as well as adding in new categories for Flathub.

Wayland will also now be primary like on the normal app but will fallback to X11 if wayland is not used.