### PR TITLE
Add zypak, Fix mistake in argument naming

### DIFF
--- a/com.mastermindzh.tidal-hifi.yml
+++ b/com.mastermindzh.tidal-hifi.yml
@@ -1,6 +1,6 @@
 app-id: com.mastermindzh.tidal-hifi
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: "22.08"
 runtime: org.freedesktop.Platform
 runtime-version: "22.08"
 sdk: org.freedesktop.Sdk

--- a/com.mastermindzh.tidal-hifi.yml
+++ b/com.mastermindzh.tidal-hifi.yml
@@ -1,4 +1,6 @@
 app-id: com.mastermindzh.tidal-hifi
+base: org.electronjs.Electron2.BaseApp
+base-version: '22.08'
 runtime: org.freedesktop.Platform
 runtime-version: "22.08"
 sdk: org.freedesktop.Sdk

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ for i in {0..9}; do
     test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
 done
 
-EXTRA_FLAGS=()
+declare -a EXTRA_FLAGS=()
 
 # Display Socket
 if [[ $XDG_SESSION_TYPE == "wayland" ]]

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ for i in {0..9}; do
     test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
 done
 
-declare -a EXTRA_FLAGS=(--no-sandbox)
+EXTRA_FLAGS=()
 
 # Display Socket
 if [[ $XDG_SESSION_TYPE == "wayland" ]]
@@ -28,4 +28,4 @@ then
 fi
 
 cd /app/lib/tidal-hifi
-exec ./tidal-hifi "${FLAGS[@]}" "$@"
+exec TMPDIR=$XDG_CACHE_HOME zypak-wrapper ./tidal-hifi "${EXTRA_FLAGS[@]}" "$@"

--- a/run.sh
+++ b/run.sh
@@ -15,14 +15,17 @@ then
     then
         echo "Wayland socket is available, running natively on Wayland."
         echo "To disable, remove the --socket=wayland permission."
-        EXTRA_FLAGS+=(--ozone-platform=wayland)
+        EXTRA_FLAGS+=(
+            "--enable-features=WaylandWindowDecorations"
+            "--ozone-platform=wayland"
+        )
     else
         echo "Wayland socket not available, running through Xwayland."
     fi
     if [[ -c /dev/nvidia0 ]]
     then
         echo "Using NVIDIA on Wayland, applying workaround"
-        EXTRA_FLAGS+=(--disable-gpu-sandbox)
+        EXTRA_FLAGS+=("--disable-gpu-sandbox")
     fi
 
 fi

--- a/run.sh
+++ b/run.sh
@@ -28,4 +28,5 @@ then
 fi
 
 cd /app/lib/tidal-hifi
-exec TMPDIR=$XDG_CACHE_HOME zypak-wrapper ./tidal-hifi "${EXTRA_FLAGS[@]}" "$@"
+export TMPDIR="$XDG_CACHE_HOME"
+exec zypak-wrapper ./tidal-hifi "${EXTRA_FLAGS[@]}" "$@"


### PR DESCRIPTION
Adds zypak which is used by most electron apps on Flatpak as well as fixes a small mistake in the naming of the array list when provided as an argument.

Closes #16 