### PR TITLE
Talk to gnome session media keys; remove duplicate notifications talk

### DIFF
--- a/com.mastermindzh.tidal-hifi.yml
+++ b/com.mastermindzh.tidal-hifi.yml
@@ -14,10 +14,11 @@ finish-args:
   - "--socket=pulseaudio"
   - "--share=network"
   - "--device=dri"
-  - "--talk-name=org.freedesktop.Notifications"
   - "--filesystem=xdg-run/app/com.discordapp.Discord:create"
   - "--own-name=org.mpris.MediaPlayer2.tidal-hifi"
   - "--talk-name=org.freedesktop.Notifications"
+  - "--talk-name=org.gnome.SettingsDaemon.MediaKeys"
+  - "--talk-name=org.gnome.SessionManager"
   - "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"
 modules:
   - name: tidal-hifi


### PR DESCRIPTION
Based on the [Spotify Flatpak](https://github.com/flathub/com.spotify.Client/blob/master/com.spotify.Client.json). 

Adds both:
- org.gnome.SessionManager
- org.gnome.SettingsDaemon.MediaKeys

to the default Session Bus Talks in order to enable media keys, at least on my setup, by default.

This also removes a duplicate 
- "--talk-name=org.freedesktop.Notifications"

Addresses #23 