### PR TITLE
Update Electron base-version and freedesktop runtime-version to 24.08

### DIFF
--- a/com.mastermindzh.tidal-hifi.yml
+++ b/com.mastermindzh.tidal-hifi.yml
@@ -1,8 +1,8 @@
 app-id: com.mastermindzh.tidal-hifi
 base: org.electronjs.Electron2.BaseApp
-base-version: "22.08"
+base-version: "24.08"
 runtime: org.freedesktop.Platform
-runtime-version: "22.08"
+runtime-version: "24.08"
 sdk: org.freedesktop.Sdk
 separate-locales: false
 command: com.mastermindzh.tidal-hifi


### PR DESCRIPTION
My naive attempt at fixing #33.

After making this change if I run `flatpak-builder --force-clean --install-deps-from=flathub builddir com.mastermindzh.tidal-hifi.yml` it get a good exit code and it _seems_ to build. I don't know how to further verify if what I did works.

I chose `24.08` by looking at the recent released on https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases & `24.08` was the most recent.

I don't know if the `base-version` and `runtime-version` values need to be tied together but they were before so I kept it that way.