### PR TITLE
Fix MPRIS

### DIFF
--- a/com.mastermindzh.tidal-hifi.yml
+++ b/com.mastermindzh.tidal-hifi.yml
@@ -16,7 +16,6 @@ finish-args:
   - "--device=dri"
   - "--filesystem=xdg-run/app/com.discordapp.Discord:create"
   - "--own-name=org.mpris.MediaPlayer2.tidal-hifi"
-  - "--own-name=org.mpris.MediaPlayer2.chromium.*"
   - "--talk-name=org.freedesktop.Notifications"
   - "--talk-name=org.kde.StatusNotifierWatcher"
   - "--talk-name=org.gnome.SettingsDaemon.MediaKeys"


### PR DESCRIPTION
Related: #52 

the mpris is `tidal-hifi` but we also had chromium as a fallback due to previous issues.

sadly, I can't test this since I don't use Tidal anymore so someone else with access to Tidal needs to test this.