### PR TITLE
Update to 6.3.0

### DIFF
--- a/com.mastermindzh.tidal-hifi.metainfo.xml
+++ b/com.mastermindzh.tidal-hifi.metainfo.xml
@@ -42,6 +42,11 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="6.3.0" date="2026-03-16">
+      <description>
+        <p>Optimizations, fixes and theming changes.</p>
+      </description>
+    </release>
     <release version="6.2.0" date="2026-02-26">
       <description>
         <p>Mpris crash handler added for videos &amp; new uploaded content.</p>

--- a/com.mastermindzh.tidal-hifi.yml
+++ b/com.mastermindzh.tidal-hifi.yml
@@ -26,8 +26,8 @@ modules:
   - name: tidal-hifi
     buildsystem: simple
     build-commands:
-      - chmod +x tidal-hifi-6.2.0.AppImage
-      - ./tidal-hifi-6.2.0.AppImage --appimage-extract
+      - chmod +x tidal-hifi-6.3.0.AppImage
+      - ./tidal-hifi-6.3.0.AppImage --appimage-extract
 
       - install -dm755 "${FLATPAK_DEST}/bin" "${FLATPAK_DEST}/lib/tidal-hifi"
       - cp -r squashfs-root/* "${FLATPAK_DEST}/lib/tidal-hifi"
@@ -43,8 +43,8 @@ modules:
       - patch-desktop-filename ${FLATPAK_DEST}/lib/tidal-hifi/resources/app.asar
     sources:
       - type: file
-        url: https://github.com/Mastermindzh/tidal-hifi/releases/download/6.2.0/tidal-hifi-6.2.0.AppImage
-        sha256: e2bcaf25aa2810c713e2e46ebaf2497dabbd648fdb3561de075f4a267f1e5b79
+        url: https://github.com/Mastermindzh/tidal-hifi/releases/download/6.3.0-Mavy/tidal-hifi-6.3.0.AppImage
+        sha256: 52ca44c4c1f93a0a7419591dde09a675d0a93d70c946269c41a6053b42a2a109
       - type: file
         path: com.mastermindzh.tidal-hifi.metainfo.xml
       - type: file


### PR DESCRIPTION
The flatpak was falling behind a few days.

Consider automating the release and publish process.

Also, building with org.freedesktop.Sdk 25.08 and org.electronjs.Electron2.BaseApp 25.08 seems to work fine.